### PR TITLE
Specify explicit jackson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
     <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
     <jersey-client.version>2.22.2</jersey-client.version>
-    <jackson.version>[2.8.11.1,)</jackson.version>
+    <jackson.version>2.8.11</jackson.version>
     <apache-commons.version>3.4</apache-commons.version>
     <junit.version>4.12</junit.version>
     <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
Using the range notation the build fails because il downloading the wrong library version

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.5.1:compile (default-compile) on project im-java-api: Compilation failure: Compilation failure:
[ERROR] /var/lib/jenkins/workspace/INDIGO/im-java-api-publish/src/main/java/es/upv/i3m/grycap/im/pojo/deserializer/InfrastructureStateDeserializer.java:[28,54] incompatible types: com.fasterxml.jackson.databind.JsonNode cannot be converted to com.fasterxml.jackson.databind.node.ObjectNode
[ERROR] /var/lib/jenkins/workspace/INDIGO/im-java-api-publish/src/main/java/es/upv/i3m/grycap/im/pojo/deserializer/PropertyDeserializer.java:[21,56] incompatible types: com.fasterxml.jackson.databind.JsonNode cannot be converted to com.fasterxml.jackson.databind.node.ObjectNode