### PR TITLE
Add force parameter

### DIFF
--- a/src/main/java/es/upv/i3m/grycap/im/InfrastructureManager.java
+++ b/src/main/java/es/upv/i3m/grycap/im/InfrastructureManager.java
@@ -275,11 +275,14 @@ public class InfrastructureManager {
    * 
    * @param infId
    *          : infrastructure id
+   * @param force
+   *          : force parameter
    */
-  public void destroyInfrastructureAsync(String infId) throws ImClientException {
+  public void destroyInfrastructureAsync(String infId, boolean force) throws ImClientException {
     RestParameter asyncParameter = createCallParameters(REST_PARAMETER_NAME_ASYNC, true);
+    RestParameter forceParameter = createCallParameters("force", force);
     getImClient().delete(PATH_INFRASTRUCTURES + PATH_SEPARATOR + infId,
-        String.class, asyncParameter);
+        String.class, asyncParameter, forceParameter);
   }
 
   /**


### PR DESCRIPTION
Regarding the [issue](https://github.com/grycap/im/issues/1518) that I have opened under the IM repo and following the suggestions received, I added the force parameter in the destroyInfrastructureAsync function. I tested its usage locally and the force parameters seems to be properly understood. If it is ok also for you, If you can also publish the new version of the package in the [maven repository](https://repository.indigo-datacloud.eu/#browse/browse:maven-releases) so that I can properly use it in the code of the orchestrator. Thank you.